### PR TITLE
Check for existing file when rendering with rmarkdown

### DIFF
--- a/code/03_create-management-report.R
+++ b/code/03_create-management-report.R
@@ -19,8 +19,10 @@ source(here::here("code", "00_setup-environment.R"))
 
 
 ### 2 - Render markdown script ----
+# render_check firsts checks if a file already exists before running rmarkdown::render
+# if a file already exists, permission must be given via the console to overwrite the file
 
-rmarkdown::render(
+render_check(
   input = here("management-report", "markdown", 
                "management-report.Rmd"),
   output_file = get_mi_output_path(test_output = test_output))

--- a/code/publication/03-knit-markdown.R
+++ b/code/publication/03-knit-markdown.R
@@ -17,7 +17,7 @@
 
 source(here::here("code", "publication", "00_setup-pub-environment.R"))
 
-render(
+render_check(
   input = here("publication", "markdown", "summary.Rmd"),
   output_file = get_pub_output_path(output_name = "pub_summary", test_output = test_output)
 )
@@ -26,7 +26,7 @@ render(
 
 source(here::here("code", "publication", "00_setup-pub-environment.R"))
 
-rmarkdown::render(
+render_check(
   input = here("publication", "markdown", "report.Rmd"),
   output_file = get_pub_output_path(output_name = "pub_report", test_output = test_output)
 )

--- a/functions/render_check.R
+++ b/functions/render_check.R
@@ -1,0 +1,32 @@
+################################################################################
+# Name of file - render_check.R
+# Original Authors - Abram McCormick
+# Original Date - August 2024
+#
+# Written/run on - RStudio Server
+# Version of R - 4.1.2
+#
+# Description - Function to run render::markdown that first checks for an existing file. If a file already exists 
+# then permission to overwrite the file must be given via the console.
+################################################################################
+
+render_check <- function(input, output_file, menu_input = 2, ...) {
+  if (file.size(output_file) != 0) {
+    menu_input <- menu(c("yes, overwrite the file (enter 0 to abort)"), title = cli::cli_alert_info("The file {.file {fs::path_file(output_file)}} already exists, are you sure you want to overwrite the file?"))
+  }
+  if (file.size(output_file) == 0 | menu_input == 1) {
+    rmarkdown::render(
+      input = input,
+      output_file = output_file)
+  }
+  if (menu_input == 1) {
+    cli::cli_alert_info("The file {.file {fs::path_file(output_file)}} has been overwritten.")
+      }
+  if (menu_input == 2) {
+      }
+  if (menu_input == 0) {
+    cli::cli_abort(message =
+       "The file {.file {fs::path_file(output_file)}} already exists and has NOT been overwritten. Re-run the section above and enter 1 in the console to overwrite file."
+    )
+  }
+}

--- a/functions/setup_directories.R
+++ b/functions/setup_directories.R
@@ -19,6 +19,9 @@ source(here::here("functions/setup_general.R"))
 # Use write file function for writing files to disk and setting correct permissions
 source(here::here("functions/write_file.R"))
 
+# Use render_check function for rendering rmarkdown files
+source(here::here("functions/render_check.R"))
+
 ### MI directory setup ###------------------------------------------------------
 
 #' Set up Management Information Directory


### PR DESCRIPTION
Created function `render_check` which first runs a check to see if a file already exists before running `rmarkdown::render`. This is now sourced in `setup_directories.R` so it is added to environment when running setup environment. `render_check` has been added to creation of MI and publication scripts.