### PR TITLE
Bug - simd is not automated

### DIFF
--- a/code/00_setup-environment.R
+++ b/code/00_setup-environment.R
@@ -79,8 +79,7 @@ cl_out <- case_when(
 ### 3 - SIMD Lookup ----
 
 simd <- function(){
-  read_rds(glue("{cl_out}/lookups/Unicode/",
-                "Deprivation/postcode_2024_2_simd2020v2.rds")) %>%
+  simd <- read_rds(get_simd_path()) %>% 
     clean_names() %>%
     select(pc7, simd = simd2020v2_sc_quintile) %>%
     mutate(
@@ -90,6 +89,8 @@ simd <- function(){
         TRUE ~ as.character(simd)
       )
     )
+  
+  return(simd)
 }
 
 


### PR DESCRIPTION
I previously set up the function to automatically pick up the simd file without having to manually correct this each time the simd file updates. I forgot to use this in place so had to manually change this during testing the mi report. This PR corrects this bug